### PR TITLE
[#1] Slackのチャレンジ認証を実装

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing Guidelines
+
+## ブランチ命名規則
+
+ブランチ名は以下の形式に従ってください：
+
+```
+<type>/i<issue-number>-<description>
+```
+
+### Type
+- `feature`: 新機能の追加
+- `fix`: バグ修正
+- `refactor`: リファクタリング（機能追加やバグ修正を含まない）
+- `docs`: ドキュメントのみの変更
+- `test`: テストの追加・修正
+- `chore`: その他の変更（ビルドスクリプト、開発環境の設定など）
+
+### Issue number
+- 必ずGitHub Issue番号を含めてください
+- 例: `i1`, `i42`
+
+### Description
+- 英語の小文字とハイフンを使用
+- 簡潔で分かりやすい説明
+
+### 例
+- `feature/i1-slack-challenge-auth`
+- `fix/i2-calendar-timezone-bug`
+- `refactor/i3-improve-error-handling`
+
+## コミットメッセージ規則
+
+コミットメッセージは以下の形式に従ってください：
+
+```
+refs #<issue-number>
+<type>: <description>
+
+[optional body]
+[optional footer]
+```
+
+### Type
+- `feat`: 新機能
+- `fix`: バグ修正
+- `docs`: ドキュメントのみの変更
+- `style`: コードスタイルの変更（スペース、フォーマット、セミコロンの追加など）
+- `refactor`: リファクタリング
+- `test`: テストの追加・修正
+- `chore`: その他の変更
+
+### Issue Reference
+- コミットメッセージの先頭に `refs #<issue-number>` を追加
+- これによりGitHub上でコミットメッセージからIssueへの自動リンクが生成されます
+- 複数のIssueを参照する場合は複数行に分けて記載
+
+### 例
+```
+refs #1
+feat: implement Slack challenge authentication
+
+- Add URL verification endpoint
+- Handle challenge parameter
+- Update appsscript.json configuration
+```
+
+## プルリクエスト（PR）規則
+
+### PRタイトル
+- Issue番号を含める
+- 変更内容を簡潔に説明
+
+例：`[#1] Implement Slack challenge authentication`
+
+### PR説明
+- 変更内容の詳細な説明
+- 関連するIssueへのリンク
+- テスト手順（必要な場合）
+- スクリーンショット（UI変更がある場合）
+
+## コードスタイル
+
+- インデントは2スペースを使用
+- セミコロンは必須
+- 関数には適切なJSDocコメントを付ける

--- a/app.gs
+++ b/app.gs
@@ -1,14 +1,23 @@
+/**
+ * Slackからのリクエストを処理する
+ * @param {Object} e POSTリクエストイベントオブジェクト
+ * @return {TextOutput} JSONレスポンス
+ */
 function doPost(e) {
   // リクエストパラメータをJSONとしてパース
-  let params = JSON.parse(e.postData.contents);
+  const params = JSON.parse(e.postData.contents);
   
-  // Slack Bot用のレスポンス
-  let response = {
+  // チャレンジ認証の場合
+  if (params.type === 'url_verification') {
+    return ContentService.createTextOutput(params.challenge);
+  }
+  
+  // その他のリクエストの場合（現時点では実装しない）
+  const response = {
     "response_type": "in_channel",
     "text": "Hello World!"
   };
   
-  // レスポンスを返す
   return ContentService.createTextOutput(JSON.stringify(response))
     .setMimeType(ContentService.MimeType.JSON);
 }

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,5 +1,5 @@
 {
-  "timeZone": "America/New_York",
+  "timeZone": "Asia/Tokyo",
   "dependencies": {
   },
   "exceptionLogging": "STACKDRIVER",


### PR DESCRIPTION
## 概要
Slackのチャレンジ認証（URL検証）機能を実装しました。

## 変更内容
- URL検証エンドポイントの追加
- challengeパラメータの処理機能の実装
- appsscript.jsonの設定更新
- 開発ガイドライン（CONTRIBUTING.md）の追加

## 関連Issue
Closes #1