### PR TITLE
[#15] 複数ユーザーの予定リストから空いている時間帯を返す処理を追加 (WIP)

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,6 +1,14 @@
 {
   "timeZone": "Asia/Tokyo",
-  "dependencies": {},
+  "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "Calendar",
+        "version": "v3",
+        "serviceId": "calendar"
+      }
+    ]
+  },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "webapp": {


### PR DESCRIPTION
# 概要

- Issue #15の実装
- 複数ユーザーの予定リストを取得し、空いている時間帯を返す処理を追加
- GeminiAPIを使用した時間帯提案機能を実装

WIP: 現在実装中であり、まだ動作確認が完了していません。
